### PR TITLE
Remove on release create in GH actions

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -1,7 +1,7 @@
 name: Linux
 on:
   release:
-    types: [published, created, edited]
+    types: [published, edited]
 
 jobs:
   build-linux-x86_64:

--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -1,7 +1,7 @@
 name: Mac OS
 on:
   release:
-    types: [published, created, edited]
+    types: [published, edited]
 
 jobs:
   build-mac:


### PR DESCRIPTION
On create was causing actions to trigger on both the creation and
publish of a release meaning duplicated builds. Removing on create so
the build only occurs on publish of the release.