### PR TITLE
Rework configuration code and allow overriding account names

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ mv ~/.aws/config.generated ~/.aws/config
 To build just run: `cargo build` in the project root.
 
 # TODO List
-* Allow setting the profile name for the organisation main account.
+* Rework code to handle setting account profile names from specified Account tags.
 * Implement verbosity, config path and output path CLI argument code.
 * Update the code to query what permission set the user has assigned to them for each account and if not assigned a permission set do not generate a profile for that account.
 * Finish implementing asdf plugin: [asdf-aws-config-generator](https://github.com/alanjjenkins/asdf-aws-config-generator)

--- a/src/configgen/generate.rs
+++ b/src/configgen/generate.rs
@@ -1,4 +1,3 @@
-use std::borrow::Borrow;
 use std::io;
 
 use aws_sdk_organizations::model::Account;
@@ -12,11 +11,21 @@ pub async fn generate_aws_config(
     sso_region: &str,
     sso_role_name: &str,
     accounts_list: &BTreeMap<String, Account>,
+    config_data: &toml::Value,
 ) -> io::Result<String> {
+    let master_account_name = match config_data.get("account_name_overrides") {
+        Some(overrides) => match overrides.get(&org_main_account) {
+            Some(name) => Some(name.as_str().unwrap().to_string()),
+            None => None,
+        },
+        None => None,
+    };
+
     let mut config_string: String = format!(
-        "[default]\nregion={}\noutput={}\n\n[profile main]\nsso_start_url = {}\nsso_region = {}\nregion = {}\noutput = {}\nsso_account_id = {}\nsso_role_name = {}\n\n",
+        "[default]\nregion={}\noutput={}\n\n[profile {}]\nsso_start_url = {}\nsso_region = {}\nregion = {}\noutput = {}\nsso_account_id = {}\nsso_role_name = {}\n\n",
         &default_region,
         &default_output_type,
+        &master_account_name.unwrap_or("main".to_string()),
         sso_start_url,
         sso_region,
         default_region,
@@ -26,27 +35,34 @@ pub async fn generate_aws_config(
     );
 
     for account in accounts_list.keys().into_iter() {
-        let mut account_name: String;
-        let account_id: &String;
-
-        match &accounts_list[account].name {
-            Some(name) => {
-                account_name = name.clone();
-                account_name = account_name.replace(" ", "-").to_lowercase();
-            }
-            None => {
-                eprintln!("No account Name!");
-                std::process::exit(1);
-            }
-        }
-
-        match &accounts_list[account].id {
-            Some(id) => account_id = &id.borrow(),
+        let account_id = match &accounts_list[account].id {
+            Some(id) => id,
             None => {
                 eprintln!("No account ID!");
                 std::process::exit(1);
             }
-        }
+        };
+
+        let mut account_name = match config_data.get("account_name_overrides") {
+            Some(overrides) => match overrides.get(&account_id) {
+                Some(name) => name.as_str().unwrap().to_string(),
+                None => "".to_string(),
+            },
+            None => String::from(""),
+        };
+
+        if account_name == "" {
+            match &accounts_list[account].name {
+                Some(name) => {
+                    account_name = name.clone();
+                    account_name = account_name.replace(" ", "-").to_lowercase();
+                }
+                None => {
+                    eprintln!("No account Name!");
+                    std::process::exit(1);
+                }
+            }
+        };
 
         config_string = config_string + &format!(
             "[profile {}]\nsso_start_url = {}\nsso_region = {}\nregion = {}\noutput = {}\nsso_account_id = {}\nsso_role_name = {}\n\n",


### PR DESCRIPTION
Reworks the configuration code to improve the error handling + error
messages. Adds the ability to override account names for accounts.