### PR TITLE
Add option to allow setting account name from account name tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,6 @@ mv ~/.aws/config.generated ~/.aws/config
 To build just run: `cargo build` in the project root.
 
 # TODO List
-* Rework code to handle setting account profile names from specified Account tags.
 * Implement verbosity, config path and output path CLI argument code.
 * Update the code to query what permission set the user has assigned to them for each account and if not assigned a permission set do not generate a profile for that account.
 * Finish implementing asdf plugin: [asdf-aws-config-generator](https://github.com/alanjjenkins/asdf-aws-config-generator)

--- a/src/bin/aws-config-generator.rs
+++ b/src/bin/aws-config-generator.rs
@@ -66,6 +66,20 @@ async fn main() -> () {
 
     let aws_cli_options = config.get("aws_cli_options").expect("aws_cli_options configuration section not found. Please see the example config and the README.md for instructions on how to configure this tool.");
     let sso_options = config.get("sso_options").expect("sso_options configuration section not found. Please see the example config and the README.md for instructions on how to configure this tool.");
+    println!("{:?}", config);
+    let name_by_account_name_tags: bool = match config.get("config") {
+        Some(config_settings) => match config_settings.get("name_by_account_name_tags") {
+            Some(should) => match should.as_bool() {
+                Some(should) => should,
+                None => {
+                    eprintln!("Error: name_by_account_name_tags must be a boolean value.");
+                    std::process::exit(1);
+                }
+            },
+            None => false,
+        },
+        None => false,
+    };
 
     let config_string = configgen::generate::generate_aws_config(
         &org_main_account.account.unwrap(),
@@ -96,6 +110,8 @@ async fn main() -> () {
             .expect("failed to convert sso_options.sso_role to a &str"),
         &accounts_list,
         &config,
+        name_by_account_name_tags,
+        org_client,
     )
     .await;
     println!(


### PR DESCRIPTION
Sets the name of the account based on the account name tags unless
otherwise overridden by the account name overrides config file setting.